### PR TITLE
AMG2023 changes

### DIFF
--- a/amg.c
+++ b/amg.c
@@ -32,7 +32,7 @@
 
 #include "HYPRE_config.h"
 #include "_hypre_utilities.h"
-#include "_hypre_seq_mv.h"
+#include "seq_mv.h"
 #include "HYPRE.h"
 #include "HYPRE_parcsr_mv.h"
 

--- a/amg.c
+++ b/amg.c
@@ -799,9 +799,9 @@ main( hypre_int argc,
       printf("UMPIRE UM Pool size %lu bytes, high water mark %lu bytes\n", umpire_um_pool_size, um_hwm);
 #ifdef USE_CALIPER
       HYPRE_Real um_pool_size = umpire_um_pool_size / (1024 * 1024 * 1024);
-      adiak_namevalue("umpire_um_pool_size", adiak_general, NULL, "%f", um_pool_size);
+      adiak_namevalue("umpire_unifiedmemory_pool_size", adiak_general, NULL, "%f", um_pool_size);
       HYPRE_Real um_hwm_gb = um_hwm / (1024 * 1024 * 1024);
-      adiak_namevalue("umpire_um_high_water_mark", adiak_general, NULL, "%f", um_hwm_gb);
+      adiak_namevalue("umpire_unifiedmemory_high_water_mark", adiak_general, NULL, "%f", um_hwm_gb);
 #endif
 #else
       size_t device_hwm = umpire_allocator_get_high_watermark(&dev_allocator);

--- a/amg.c
+++ b/amg.c
@@ -32,7 +32,7 @@
 
 #include "HYPRE_config.h"
 #include "_hypre_utilities.h"
-#include "seq_mv.h"
+#include "_hypre_seq_mv.h"
 #include "HYPRE.h"
 #include "HYPRE_parcsr_mv.h"
 

--- a/amg.c
+++ b/amg.c
@@ -799,18 +799,18 @@ main( hypre_int argc,
       printf("UMPIRE UM Pool size %lu bytes, high water mark %lu bytes\n", umpire_um_pool_size, um_hwm);
 #ifdef USE_CALIPER
       HYPRE_Real um_pool_size = umpire_um_pool_size / (1024 * 1024 * 1024);
-      adiak_namevalue("um_pool_size", adiak_general, NULL, "%f", um_pool_size);
+      adiak_namevalue("umpire_um_pool_size", adiak_general, NULL, "%f", um_pool_size);
       HYPRE_Real um_hwm_gb = um_hwm / (1024 * 1024 * 1024);
-      adiak_namevalue("um_hwm", adiak_general, NULL, "%f", um_hwm_gb);
+      adiak_namevalue("umpire_um_high_water_mark", adiak_general, NULL, "%f", um_hwm_gb);
 #endif
 #else
       size_t dev_hwm = umpire_allocator_get_high_watermark(&dev_allocator);
       printf("UMPIRE Device Pool size %lu bytes, high water mark %lu bytes\n", umpire_dev_pool_size, dev_hwm);
 #ifdef USE_CALIPER
       HYPRE_Real dev_pool_size = umpire_dev_pool_size / (1024 * 1024 * 1024);
-      adiak_namevalue("dev_pool_size", adiak_general, NULL, "%f", dev_pool_size);
+      adiak_namevalue("umpire_device_pool_size", adiak_general, NULL, "%f", dev_pool_size);
       HYPRE_Real dev_hwm_gb = dev_hwm / (1024 * 1024 * 1024);
-      adiak_namevalue("dev_hwm", adiak_general, NULL, "%f", dev_hwm_gb);
+      adiak_namevalue("umpire_device_high_water_mark", adiak_general, NULL, "%f", dev_hwm_gb);
 #endif
 #endif
    }

--- a/amg.c
+++ b/amg.c
@@ -804,13 +804,13 @@ main( hypre_int argc,
       adiak_namevalue("umpire_um_high_water_mark", adiak_general, NULL, "%f", um_hwm_gb);
 #endif
 #else
-      size_t dev_hwm = umpire_allocator_get_high_watermark(&dev_allocator);
-      printf("UMPIRE Device Pool size %lu bytes, high water mark %lu bytes\n", umpire_dev_pool_size, dev_hwm);
+      size_t device_hwm = umpire_allocator_get_high_watermark(&dev_allocator);
+      printf("UMPIRE Device Pool size %lu bytes, high water mark %lu bytes\n", umpire_dev_pool_size, device_hwm);
 #ifdef USE_CALIPER
-      HYPRE_Real dev_pool_size = umpire_dev_pool_size / (1024 * 1024 * 1024);
-      adiak_namevalue("umpire_device_pool_size", adiak_general, NULL, "%f", dev_pool_size);
-      HYPRE_Real dev_hwm_gb = dev_hwm / (1024 * 1024 * 1024);
-      adiak_namevalue("umpire_device_high_water_mark", adiak_general, NULL, "%f", dev_hwm_gb);
+      HYPRE_Real device_pool_size = umpire_dev_pool_size / (1024 * 1024 * 1024);
+      adiak_namevalue("umpire_device_pool_size", adiak_general, NULL, "%f", device_pool_size);
+      HYPRE_Real device_hwm_gb = device_hwm / (1024 * 1024 * 1024);
+      adiak_namevalue("umpire_device_high_water_mark", adiak_general, NULL, "%f", device_hwm_gb);
 #endif
 #endif
    }

--- a/amg.c
+++ b/amg.c
@@ -798,6 +798,8 @@ main( hypre_int argc,
       size_t um_hwm = umpire_allocator_get_high_watermark(&um_allocator);
       printf("UMPIRE UM Pool size %lu bytes, high water mark %lu bytes\n", umpire_um_pool_size, um_hwm);
 #ifdef USE_CALIPER
+      HYPRE_Real um_pool_size = umpire_um_pool_size / (1024 * 1024 * 1024);
+      adiak_namevalue("um_pool_size", adiak_general, NULL, "%f", um_pool_size);
       HYPRE_Real um_hwm_gb = um_hwm / (1024 * 1024 * 1024);
       adiak_namevalue("um_hwm", adiak_general, NULL, "%f", um_hwm_gb);
 #endif
@@ -805,6 +807,8 @@ main( hypre_int argc,
       size_t dev_hwm = umpire_allocator_get_high_watermark(&dev_allocator);
       printf("UMPIRE Device Pool size %lu bytes, high water mark %lu bytes\n", umpire_dev_pool_size, dev_hwm);
 #ifdef USE_CALIPER
+      HYPRE_Real dev_pool_size = umpire_dev_pool_size / (1024 * 1024 * 1024);
+      adiak_namevalue("dev_pool_size", adiak_general, NULL, "%f", dev_pool_size);
       HYPRE_Real dev_hwm_gb = dev_hwm / (1024 * 1024 * 1024);
       adiak_namevalue("dev_hwm", adiak_general, NULL, "%f", dev_hwm_gb);
 #endif

--- a/amg.c
+++ b/amg.c
@@ -797,9 +797,17 @@ main( hypre_int argc,
 #if defined(HYPRE_USING_UNIFIED_MEMORY)
       size_t um_hwm = umpire_allocator_get_high_watermark(&um_allocator);
       printf("UMPIRE UM Pool size %lu bytes, high water mark %lu bytes\n", umpire_um_pool_size, um_hwm);
+#ifdef USE_CALIPER
+      HYPRE_Real um_hwm_gb = um_hwm / (1024 * 1024 * 1024);
+      adiak_namevalue("um_hwm", adiak_general, NULL, "%f", um_hwm_gb);
+#endif
 #else
       size_t dev_hwm = umpire_allocator_get_high_watermark(&dev_allocator);
       printf("UMPIRE Device Pool size %lu bytes, high water mark %lu bytes\n", umpire_dev_pool_size, dev_hwm);
+#ifdef USE_CALIPER
+      HYPRE_Real dev_hwm_gb = dev_hwm / (1024 * 1024 * 1024);
+      adiak_namevalue("dev_hwm", adiak_general, NULL, "%f", dev_hwm_gb);
+#endif
 #endif
    }
 #endif

--- a/amg.c
+++ b/amg.c
@@ -419,9 +419,9 @@ main( hypre_int argc,
    HYPRE_SetUmpireUMPoolName(um_pool_name);
    /* allocate and free some memory to make sure pool is allocated */
 #if defined(HYPRE_USING_UNIFIED_MEMORY)
-   char *tmp_ptr = hypre_TAlloc(char, umpire_um_pool_size, memory_location);
+   char *tmp_ptr = hypre_TAlloc(char, 1024, memory_location);
 #else
-   char *tmp_ptr = hypre_TAlloc(char, umpire_dev_pool_size, memory_location);
+   char *tmp_ptr = hypre_TAlloc(char, 1024, memory_location);
 #endif
    hypre_TFree(tmp_ptr, memory_location);
    /* make sure hypre doesn't own the pools */

--- a/amg.c
+++ b/amg.c
@@ -32,7 +32,8 @@
 
 #include "HYPRE_config.h"
 #include "_hypre_utilities.h"
-#include "_hypre_seq_mv.h"
+#include "seq_mv.h"
+//#include "_hypre_seq_mv.h"
 #include "HYPRE.h"
 #include "HYPRE_parcsr_mv.h"
 

--- a/amg.c
+++ b/amg.c
@@ -32,8 +32,11 @@
 
 #include "HYPRE_config.h"
 #include "_hypre_utilities.h"
+#if HYPRE_RELEASE_NUMBER > 23300
+#include "_hypre_seq_mv.h"
+#else
 #include "seq_mv.h"
-//#include "_hypre_seq_mv.h"
+#endif
 #include "HYPRE.h"
 #include "HYPRE_parcsr_mv.h"
 


### PR DESCRIPTION
This PR:
1. Uses a small memory block (1024 bytes) to initially "warm up" the device/UM memory pool instead of allocating the entire pool size. This fixes the incorrect memory high water mark reported by the application.
2. Adds a hypre version check to support older hypre versions